### PR TITLE
Add modify function

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,13 +1,29 @@
 <?php
 
+use Morilog\Jalali\jDate;
+
 if (! function_exists('jdate')) {
 
     /**
      * @param string $str
-     * @return \Morilog\Jalali\jDate
+     * @return jDate
      */
     function jdate($str = null)
     {
-        return \Morilog\Jalali\jDate::forge($str);
+        return jDate::forge($str);
+    }
+}
+
+if (! function_exists('jdate_modify')) {
+
+    /**
+     * @param jDate $jDate
+     * @param string $modify
+     * @return jDate
+     * @internal param string $str
+     */
+    function jdate_modify(jDate &$jDate, $modify)
+    {
+        $jDate = $jDate->modify($modify);
     }
 }

--- a/src/jDate.php
+++ b/src/jDate.php
@@ -52,6 +52,62 @@ class jDate
     }
 
     /**
+     * Create a new jDate instance from a specific Jalali date and time.
+     *
+     * If any of $year, $month or $day are set to null, their now() values will
+     * be used.
+     *
+     * If any of $hour, $minute or $second are set to null, 0 will be used.
+     *
+     * If no params are passed, now() values will be returned.
+     *
+     * @param null $year
+     * @param null $month
+     * @param null $day
+     * @param null $hour
+     * @param null $minute
+     * @param null $second
+     * @param null $tz
+     * @return jDate
+     */
+    public static function create($year = null, $month = null, $day = null, $hour = null, $minute = null, $second = null, $tz = null)
+    {
+        $now = new jDate(null, $tz);
+
+        if ($year === null) {
+            return $now;
+        }
+
+        $defaults = array_combine(array(
+            'year',
+            'month',
+            'day',
+        ), explode('-', $now->format('Y-n-j')));
+
+        $year = $year === null ? $defaults['year'] : $year;
+        $month = $month === null ? $defaults['month'] : $month;
+        $day = $day === null ? $defaults['day'] : $day;
+        $hour = $hour === null ? 0 : $hour;
+        $minute = $minute === null ? 0 : $minute;
+        $second = $second === null ? 0 : $second;
+
+        static::fixWraps($year, $month, $day, $hour, $minute, $second);
+
+        $gregorian = jDateTime::toGregorian($year, $month, $day);
+
+        $year = str_pad($gregorian[0], 4, "0", STR_PAD_LEFT);
+        $month = str_pad($gregorian[1], 2, "0", STR_PAD_LEFT);
+        $day = str_pad($gregorian[2], 2, "0", STR_PAD_LEFT);
+        $hour = str_pad($hour, 2, "0", STR_PAD_LEFT);
+        $minute = str_pad($minute, 2, "0", STR_PAD_LEFT);
+        $second = str_pad($second, 2, "0", STR_PAD_LEFT);
+
+        $dateString = "{$year}-{$month}-{$day} {$hour}:{$minute}:{$second}";
+
+        return static::forge($dateString, $tz);
+    }
+
+    /**
      * @param string|null $str
      * @param null $timezone
      */

--- a/src/jDate.php
+++ b/src/jDate.php
@@ -27,7 +27,7 @@ use Carbon\Carbon;
 class jDate
 {
     /**
-     * @var \DateTime
+     * @var Carbon
      */
     protected $dateTime;
 
@@ -61,7 +61,7 @@ class jDate
     }
 
     /**
-     * @return \DateTime|static
+     * @return Carbon
      */
     public function getDateTime()
     {

--- a/src/jDate.php
+++ b/src/jDate.php
@@ -54,10 +54,11 @@ class jDate
     /**
      * Create a new jDate instance from a specific Jalali date and time.
      *
-     * If any of $year, $month or $day are set to null, their now() values will
+     * If any of $year, $month or $day are set to null their now() values will
      * be used.
      *
-     * If any of $hour, $minute or $second are set to null, 0 will be used.
+     * If $hour is null it will be set to its now() value and the default
+     * values for $minute and $second will be their now() values.
      *
      * If no params are passed, now() values will be returned.
      *
@@ -74,22 +75,27 @@ class jDate
     {
         $now = new jDate(null, $tz);
 
-        if ($year === null) {
-            return $now;
-        }
-
         $defaults = array_combine(array(
             'year',
             'month',
             'day',
-        ), explode('-', $now->format('Y-n-j')));
+            'hour',
+            'minute',
+            'second',
+        ), explode('-', $now->format('Y-n-j-G-i-s')));
 
         $year = $year === null ? $defaults['year'] : $year;
         $month = $month === null ? $defaults['month'] : $month;
         $day = $day === null ? $defaults['day'] : $day;
-        $hour = $hour === null ? 0 : $hour;
-        $minute = $minute === null ? 0 : $minute;
-        $second = $second === null ? 0 : $second;
+
+        if ($hour === null) {
+            $hour = $defaults['hour'];
+            $minute = $minute === null ? $defaults['minute'] : $minute;
+            $second = $second === null ? $defaults['second'] : $second;
+        } else {
+            $minute = $minute === null ? 0 : $minute;
+            $second = $second === null ? 0 : $second;
+        }
 
         static::fixWraps($year, $month, $day, $hour, $minute, $second);
 

--- a/src/jDateTime.php
+++ b/src/jDateTime.php
@@ -795,7 +795,7 @@ class jDateTime
     /**
      * @param $timestamp
      * @param null $timezone
-     * @return \DateTime|static
+     * @return Carbon
      */
     public static function createDateTime($timestamp = null, $timezone = null)
     {
@@ -811,7 +811,7 @@ class jDateTime
         }
 
         if (is_string($timestamp)) {
-            return new \DateTime($timestamp, $timezone);
+            return new Carbon($timestamp, $timezone);
         }
 
         if (is_numeric($timestamp)) {

--- a/tests/CreateTest.php
+++ b/tests/CreateTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Morilog\Jalali\jDate;
+
+class CreateTest extends PHPUnit_Framework_TestCase
+{
+    public function testCreate()
+    {
+        $jDate1 = jdate('2015-06-03');
+        $jDate2 = jDate::create(1394, 3, 13);
+
+        $this->assertSame($jDate1->format('Y-m-d H:i'), $jDate2->format('Y-m-d H:i'));
+    }
+
+    public function testCreateNow()
+    {
+        $jDate1 = jdate();
+        $jDate2 = jDate::create();
+
+        $this->assertSame($jDate1->format('Y-m-d H:i:s'), $jDate2->format('Y-m-d H:i:s'));
+    }
+}

--- a/tests/CreateTest.php
+++ b/tests/CreateTest.php
@@ -9,7 +9,7 @@ class CreateTest extends PHPUnit_Framework_TestCase
         $jDate1 = jdate('2015-06-03');
         $jDate2 = jDate::create(1394, 3, 13);
 
-        $this->assertSame($jDate1->format('Y-m-d H:i'), $jDate2->format('Y-m-d H:i'));
+        $this->assertSame($jDate1->format('Y-m-d'), $jDate2->format('Y-m-d'));
     }
 
     public function testCreateNow()

--- a/tests/ModifyTest.php
+++ b/tests/ModifyTest.php
@@ -1,0 +1,264 @@
+<?php
+
+use Carbon\Carbon;
+use Morilog\Jalali\jDate;
+
+class ModifyTest extends PHPUnit_Framework_TestCase
+{
+    /* ***************************************************************************
+     *  Set Date and time with Modify function
+     * ***************************************************************************
+     */
+    public function testSetDateTimeWithModify()
+    {
+        $jDate = jDate::create(1395, 1, 5, 20, 30, 0)->modify('1394-03-30 15:30:10');
+        $this->assertSame('1394-03-30 15:30:10', $jDate->format('Y-m-d H:i:s'));
+    }
+
+    /* ***************************************************************************
+     *  Year
+     * ***************************************************************************
+     */
+    public function testAddAYear()
+    {
+        $jDate = jDate::create(1394, 3, 30, 20, 30, 0)->modify('+1 year');
+        $this->assertSame('1395-03-30 20:30:00', $jDate->format('Y-m-d H:i:s'));
+    }
+
+    public function testAdd5Years()
+    {
+        $jDate = jDate::create(1394, 3, 30)->modify('+5 years');
+        $this->assertSame('1399-03-30', $jDate->format('Y-m-d'));
+    }
+
+    public function testSub4Years()
+    {
+        $jDate = jDate::create(1394, 3, 30)->modify('-4 years');
+        $this->assertSame('1390-03-30', $jDate->format('Y-m-d'));
+    }
+
+    /* ***************************************************************************
+     *  Month
+     * ***************************************************************************
+     */
+    public function testAdd1Month()
+    {
+        $jDate = jDate::create(1394, 3, 30)->modify('+1 month');
+        $this->assertSame('1394-04-30', $jDate->format('Y-m-d'));
+    }
+
+    public function testAdd6Months()
+    {
+        $jDate = jDate::create(1394, 3, 31)->modify('+6 month');
+        $this->assertSame('1394-10-01', $jDate->format('Y-m-d'));
+        // This behaviour happens in original DateTime and Carbon too.
+        // I don't know if it's ok to change this behaviour
+        // in order to get "1394-09-30" or not.
+    }
+
+    public function testSub6Months()
+    {
+        $jDate = jDate::create(1394, 3, 10)->modify('-6 month');
+        $this->assertSame('1393-09-10', $jDate->format('Y-m-d'));
+    }
+
+//    public function testSub2MonthsAgo()
+//    {
+//        $jDate = jDate::create(1394, 3, 10)->modify('-2 month ago');
+//        $this->assertSame('1394-01-10', $jDate->format('Y-m-d'));
+//    }
+
+    /* ***************************************************************************
+     *  Modify Days
+     * ***************************************************************************
+     */
+    public function testAdd22Days()
+    {
+        $jDate = jDate::create(1394, 3, 10)->modify('22 days');
+        $this->assertSame('1394-04-01', $jDate->format('Y-m-d'));
+    }
+
+    public function testSub1Days()
+    {
+        $jDate = jDate::create(1394, 3, 10)->modify('-11 Days');
+        $this->assertSame('1394-02-30', $jDate->format('Y-m-d'));
+    }
+
+    /* ***************************************************************************
+     *  Modify Weekdays
+     * ***************************************************************************
+     */
+    public function testAdd2Weekdays()
+    {
+        $jDate = jDate::create(1395, 9, 10)->modify('+2 weekdays');
+        $this->assertSame('1395-09-13', $jDate->format('Y-m-d'));
+    }
+
+    public function testAdd15Weekdays()
+    {
+        $jDate = jDate::create(1395, 9, 10)->modify('+15 weekdays');
+        $this->assertSame('1395-09-28', $jDate->format('Y-m-d'));
+    }
+
+    public function testSub4Weekdays()
+    {
+        $jDate = jDate::create(1395, 9, 10)->modify('-4 weekdays');
+        $this->assertSame('1395-09-06', $jDate->format('Y-m-d'));
+    }
+
+    public function testSub15Weekdays()
+    {
+        $jDate = jDate::create(1395, 9, 10)->modify('-15 weekdays');
+        $this->assertSame('1395-08-23', $jDate->format('Y-m-d'));
+    }
+
+    /* ***************************************************************************
+     *  Complicated Modify
+     * ***************************************************************************
+     */
+    public function testAdd6YearsToADate()
+    {
+        $jDate = jDate::create()->modify('1394-03-30 +6 years');
+        $this->assertSame('1400-03-30', $jDate->format('Y-m-d'));
+    }
+
+    public function testAdd2YearsToADateTime()
+    {
+        $jDate = jDate::create()->modify('1394-03-30 10:11:20 +2 years');
+        $this->assertSame('1396-03-30 10:11:20', $jDate->format('Y-m-d H:i:s'));
+    }
+
+    public function testSetDateSub11DaysAdd3Months()
+    {
+        $jDate = jDate::create()->modify('1394-03-30 +3 months -11 days');
+        $this->assertSame('1394-06-19', $jDate->format('Y-m-d'));
+    }
+
+    public function testSetDateAdd14weekday()
+    {
+        $jDate = jDate::create()->modify('1395-01-14 +14 weekdays');
+        $this->assertSame('1395-01-30', $jDate->format('Y-m-d'));
+    }
+
+    /* ***************************************************************************
+     *  Set Date By String
+     * ***************************************************************************
+     */
+    public function testSetFullDateByString()
+    {
+        $carbon = Carbon::create()->modify('1 December 2016');
+        $this->assertSame('2016-12-01', $carbon->format('Y-m-d'));
+
+        $jDate = jDate::create()->modify('11 azar 1390');
+        $this->assertSame('1390-09-11', $jDate->format('Y-m-d'));
+    }
+
+    public function testSetYearAndMonthByString()
+    {
+        $carbon = Carbon::create()->modify('january 2016');
+        $this->assertSame('2016-01-01', $carbon->format('Y-m-d'));
+
+        $jDate = jDate::create()->modify('esfand 1390');
+        $this->assertSame('1390-12-01', $jDate->format('Y-m-d'));
+    }
+
+    public function testSetMonthAndDayOfCurrentYearByString()
+    {
+        $year = jDate::create()->format('Y');
+
+        $jDate = jDate::create()->modify('1 Farvardin');
+        $this->assertSame("$year-01-01", $jDate->format('Y-m-d'));
+    }
+
+    public function testSetFullDateByStringAndAdd3Days()
+    {
+        $carbon = Carbon::create()->modify('1 March 2016 +3 days');
+        $this->assertSame('2016-03-04', $carbon->format('Y-m-d'));
+
+        $jDate = jDate::create()->modify('1 azar 1395 +3 days');
+        $this->assertSame('1395-09-04', $jDate->format('Y-m-d'));
+    }
+
+
+    /* ***************************************************************************
+     *  Next | previous | current
+     * ***************************************************************************
+     */
+    public function testNextYear()
+    {
+        $nextYear = jDate::create()->modify('+1 year')->format('Y-m-d');
+
+        $jDate = jDate::create()->modify('next year');
+        $this->assertSame($nextYear, $jDate->format('Y-m-d'));
+    }
+
+    public function testPreviousMonth()
+    {
+        $previousMonth = jDate::create()->modify('-1 month')->format('Y-m-d');
+
+        $jDate = jDate::create()->modify('previous month');
+        $this->assertSame($previousMonth, $jDate->format('Y-m-d'));
+    }
+
+    public function testNextDay()
+    {
+        $nextDay = jDate::create()->modify('+1 day')->format('Y-m-d');
+
+        $jDate = jDate::create()->modify('next day');
+        $this->assertSame($nextDay, $jDate->format('Y-m-d'));
+    }
+
+    /* ***************************************************************************
+     *  ( first | last ) day of
+     * ***************************************************************************
+     */
+    public function testFirstOfThisMonth()
+    {
+	    $carbon = Carbon::create(2016,11,10)->modify('first day of this month');
+	    $this->assertSame('2016-11-01', $carbon->format('Y-m-d'));
+	    $this->assertNotSame('00:00:00', $carbon->format('H:i:s'));
+
+        $jDate = jDate::create(1395,5,22)->modify('first day of this month');
+        $this->assertSame("1395-05-01", $jDate->format('Y-m-d'));
+	    $this->assertNotSame('00:00:00', $jDate->format('H:i:s'));
+    }
+
+    public function testFirstOfNextMonth()
+    {
+	    $jDate = jDate::create(1395,5,22)->modify('first day of next month');
+	    $this->assertSame("1395-06-01", $jDate->format('Y-m-d'));
+    }
+
+    public function testFirstDayOfEsfand1357()
+    {
+	    $jDate = jDate::create()->modify('first day of esfand 1395');
+	    $this->assertSame("1395-12-01", $jDate->format('Y-m-d'));
+    }
+
+	public function testLastDayOfThisMonth()
+	{
+		$carbon = Carbon::create(2016,11,10)->modify('last day of this month');
+		$this->assertSame('2016-11-30', $carbon->format('Y-m-d'));
+		$this->assertNotSame('23:59:59', $carbon->format('H:i:s'));
+
+		$jDate = jDate::create(1395,8,7)->modify('last day of this month');
+		$this->assertSame("1395-08-30", $jDate->format('Y-m-d'));
+		$this->assertNotSame('23:59:59', $jDate->format('H:i:s'));
+	}
+
+	public function testLastDayOfNextMonth()
+	{
+		$jDate = jDate::create(1395,8,7)->modify('last day of next month');
+		$this->assertSame("1395-09-30", $jDate->format('Y-m-d'));
+	}
+
+    public function testLastDayOfEsfand1357()
+    {
+        $jDate = jDate::create()->modify('last day of esfand 1357');
+        $this->assertSame("1357-12-29", $jDate->format('Y-m-d'));
+
+	    $jDate = jDate::create()->modify('last day of esfand 1395');
+	    $this->assertSame("1395-12-30", $jDate->format('Y-m-d'));
+    }
+
+}

--- a/tests/jDateTimeTest.php
+++ b/tests/jDateTimeTest.php
@@ -94,7 +94,7 @@ class jDateTimeTest extends PHPUnit_Framework_TestCase
 
         $tzOffset = $this->getTimeZoneOffset('Asia/Tehran', 'UTC');
 
-        $this->assertTrue((((($utcHour * 60) + $utcMin) * 60) - ((($tehranHour * 60) + $tehranMin) * 60)) === $tzOffset);
+        $this->assertTrue((((($utcHour * 60) + $utcMin) * 60) - ((($tehranHour * 60) + $tehranMin) * 60)) === $tzOffset, 'Note: this test fails between 00:00 and 3:30AM');
 
     }
 


### PR DESCRIPTION
This PR is created to add Jalali-base modify function to jDate

Not all modifications are available but it is usable and fully tested this far. These are some examples of features that are added to jDate:

```
$jDate = jDate::create() // Now
$jDate = $jDate->modify('1394-03-10 15:30:10'); // 1394-03-10 15:30:10
$jDate = $jDate->modify('+1 year');  //1395-03-10 15:30:10
$jDate = $jDate->modify('+6 month');  //1395-09-10 15:30:10
$jDate = $jDate->modify('+1 day');  //1395-09-11 15:30:10
$jDate = $jDate->modify('+8 weekdays')  //1395-09-21 15:30:10
$jDate = $jDate->modify('next year'); //1396-09-21 15:30:10

$jDate = $jDate->modify('first day of next month');  //1396-10-01 15:30:10
$jDate = $jDate->modify('last day of esfand 1395');  //1395-12-30 15:30:10
```