### PR TITLE
Change composer install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ morilog/jalali
 
 Run the Composer update command
 
-    $ composer require morilog/jalali:3.*
+    $ composer require "morilog/jalali:3.*"
 
 <a name="basic-usage"></a>
 ## Basic Usage


### PR DESCRIPTION
fix "no matches found" error by add double quotations to composer command