### PR TITLE
Add new methods

### DIFF
--- a/src/Jalalian.php
+++ b/src/Jalalian.php
@@ -165,6 +165,73 @@ class Jalalian
         );
     }
 
+    public function getFirstDayOfQuarter(): Jalalian
+    {
+        return new static(
+            $this->getYear(),
+            ($this->getQuarter() - 1) * Carbon::MONTHS_PER_QUARTER,
+            1,
+            $this->getHour(),
+            $this->getMinute(),
+            $this->getSecond(),
+            $this->getTimezone()
+        );
+    }
+
+    public function getEndDayOfWeek(): Jalalian
+    {
+        $endWeek = $this->subDays(6 - $this->getDayOfWeek());
+
+        return (new static(
+            $endWeek->getYear(),
+            $endWeek->getMonth(),
+            $endWeek->getDay(),
+            $endWeek->getHour(),
+            $endWeek->getMinute(),
+            $endWeek->getSecond(),
+            $endWeek->getTimezone()
+        ));
+    }
+
+    public function getEndDayOfMonth(): Jalalian
+    {
+        return new static(
+            $this->getYear(),
+            $this->getMonth(),
+            $this->getDaysOf($this->getMonth()),
+            $this->getHour(),
+            $this->getMinute(),
+            $this->getSecond(),
+            $this->getTimezone()
+        );
+    }
+
+    public function getEndDayOfYear(): Jalalian
+    {
+        return new static(
+            $this->getYear(),
+            12,
+            $this->getDaysOf($this->getMonth()),
+            $this->getHour(),
+            $this->getMinute(),
+            $this->getSecond(),
+            $this->getTimezone()
+        );
+    }
+
+    public function getEndDayOfQuarter(): Jalalian
+    {
+        return new static(
+            $this->getYear(),
+            $this->getQuarter() * Carbon::MONTHS_PER_QUARTER,
+            $this->getDaysOf($this->getQuarter() * Carbon::MONTHS_PER_QUARTER),
+            $this->getHour(),
+            $this->getMinute(),
+            $this->getSecond(),
+            $this->getTimezone()
+        );
+    }
+
     public function getMonthDays()
     {
         if ($this->getMonth() <= 6) {
@@ -197,6 +264,11 @@ class Jalalian
     public function getYear()
     {
         return $this->year;
+    }
+
+    public function getQuarter(): int
+    {
+        return (int) ceil($this->getMonth() / Carbon::MONTHS_PER_QUARTER);
     }
 
     public function subMonths(int $months = 1): Jalalian

--- a/src/Jalalian.php
+++ b/src/Jalalian.php
@@ -169,7 +169,7 @@ class Jalalian
     {
         return new static(
             $this->getYear(),
-            ($this->getQuarter() - 1) * Carbon::MONTHS_PER_QUARTER,
+            ($this->getQuarter() - 1) * Carbon::MONTHS_PER_QUARTER + 1,
             1,
             $this->getHour(),
             $this->getMinute(),
@@ -180,7 +180,7 @@ class Jalalian
 
     public function getEndDayOfWeek(): Jalalian
     {
-        $endWeek = $this->subDays(6 - $this->getDayOfWeek());
+        $endWeek = $this->addDays(6 - $this->getDayOfWeek());
 
         return (new static(
             $endWeek->getYear(),
@@ -211,7 +211,7 @@ class Jalalian
         return new static(
             $this->getYear(),
             12,
-            $this->getDaysOf($this->getMonth()),
+            $this->getDaysOf(12),
             $this->getHour(),
             $this->getMinute(),
             $this->getSecond(),

--- a/tests/JalalianTest.php
+++ b/tests/JalalianTest.php
@@ -160,7 +160,7 @@ final class JalalianTest extends TestCase
         $jDate = new Jalalian(1401, 3, 7);
         $this->assertEquals($jDate->getWeekOfMonth(), 2);
     }
-    
+
     public function testGetFirstDayOfWeek()
     {
         $jDate = new Jalalian(1401, 1, 23);
@@ -228,5 +228,146 @@ final class JalalianTest extends TestCase
     {
         $jDate = new Jalalian(1401, 6, 8);
         $this->assertEquals($jDate->getLastMonth()->format('Y-m-d'), '1401-05-08');
+    }
+
+    public function testGetFirstDayOfQuarter()
+    {
+        $jDate = new Jalalian(1402, 1, 25);
+        $this->assertEquals('1402-01-01', $jDate->getFirstDayOfQuarter()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 2, 25);
+        $this->assertEquals('1402-01-01', $jDate->getFirstDayOfQuarter()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 3, 25);
+        $this->assertEquals('1402-01-01', $jDate->getFirstDayOfQuarter()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 4, 25);
+        $this->assertEquals('1402-04-01', $jDate->getFirstDayOfQuarter()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 5, 25);
+        $this->assertEquals('1402-04-01', $jDate->getFirstDayOfQuarter()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 6, 25);
+        $this->assertEquals('1402-04-01', $jDate->getFirstDayOfQuarter()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 7, 25);
+        $this->assertEquals('1402-07-01', $jDate->getFirstDayOfQuarter()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 8, 25);
+        $this->assertEquals('1402-07-01', $jDate->getFirstDayOfQuarter()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 9, 25);
+        $this->assertEquals('1402-07-01', $jDate->getFirstDayOfQuarter()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 10, 25);
+        $this->assertEquals('1402-10-01', $jDate->getFirstDayOfQuarter()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 11, 19);
+        $this->assertEquals('1402-10-01', $jDate->getFirstDayOfQuarter()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 12, 25);
+        $this->assertEquals('1402-10-01', $jDate->getFirstDayOfQuarter()->format('Y-m-d'));
+
+    }
+
+    public function testGetEndDayOfWeek()
+    {
+        /*
+         *  --------------------------------
+         *       Day 1402 (March 2024)
+         *  --------------------------------
+         *    Sat Sun Mon Tue Wed Thu Fri
+         *  --------------------------------
+         *                             1
+         *     2   3   4   5   6   7   8
+         *     9  10  11  12  13  14  15
+         *    16  17  18  19  20  21  22
+         *    23  24  25  26  27  28  29
+         *    30
+         *  -------------------------------
+         */
+
+        $jDate = new Jalalian(1402, 10, 25);
+        $this->assertEquals('1402-10-29', $jDate->getEndDayOfWeek()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 10, 29);
+        $this->assertEquals('1402-10-29', $jDate->getEndDayOfWeek()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 10, 23);
+        $this->assertEquals('1402-10-29', $jDate->getEndDayOfWeek()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 12, 29);
+        $this->assertEquals('1403-01-03', $jDate->getEndDayOfWeek()->format('Y-m-d'));
+
+    }
+
+    public function testGetEndDayOfMonth()
+    {
+        /*
+         *  --------------------------------
+         *       Day 1402 (March 2024)
+         *  --------------------------------
+         *    Sat Sun Mon Tue Wed Thu Fri
+         *  --------------------------------
+         *                             1
+         *     2   3   4   5   6   7   8
+         *     9  10  11  12  13  14  15
+         *    16  17  18  19  20  21  22
+         *    23  24  25  26  27  28  29
+         *    30
+         *  -------------------------------
+         */
+
+        $jDate = new Jalalian(1402, 10, 25);
+        $this->assertEquals('1402-10-30', $jDate->getEndDayOfMonth()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 04, 12);
+        $this->assertEquals('1402-04-31', $jDate->getEndDayOfMonth()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 12, 25);
+        $this->assertEquals('1402-12-29', $jDate->getEndDayOfMonth()->format('Y-m-d'));
+    }
+
+    public function testGetEndDayOfYear()
+    {
+        $jDate = new Jalalian(1402, 10, 25);
+        $this->assertEquals('1402-12-29', $jDate->getEndDayOfYear()->format('Y-m-d'));
+
+        // LeapYear
+        $jDate = new Jalalian(1403, 10, 25);
+        $this->assertEquals('1403-12-30', $jDate->getEndDayOfYear()->format('Y-m-d'));
+    }
+
+    public function testGetEndDayOfQuarter()
+    {
+        $jDate = new Jalalian(1402, 10, 25);
+        $this->assertEquals('1402-12-29', $jDate->getEndDayOfQuarter()->format('Y-m-d'));
+
+        $jDate = new Jalalian(1402, 2, 25);
+        $this->assertEquals('1402-03-31', $jDate->getEndDayOfQuarter()->format('Y-m-d'));
+
+
+        $jDate = new Jalalian(1402, 6, 01);
+        $this->assertEquals('1402-06-31', $jDate->getEndDayOfQuarter()->format('Y-m-d'));
+
+
+        $jDate = new Jalalian(1402, 9, 01);
+        $this->assertEquals('1402-09-30', $jDate->getEndDayOfQuarter()->format('Y-m-d'));
+    }
+
+    public function testGetQuarter()
+    {
+        $jDate = new Jalalian(1402, 10, 25);
+        $this->assertEquals(4, $jDate->getQuarter());
+
+        $jDate = new Jalalian(1402, 1, 01);
+        $this->assertEquals(1, $jDate->getQuarter());
+
+
+        $jDate = new Jalalian(1402, 05, 24);
+        $this->assertEquals(2, $jDate->getQuarter());
+
+        $jDate = new Jalalian(1402, 7, 23);
+        $this->assertEquals(3, $jDate->getQuarter());
     }
 }


### PR DESCRIPTION
Hi,

This PR introduces several new methods to the package. The added methods are as follows:
---
`getFirstDayOfQuarter`: Retrieves the first day of the current quarter.

`getEndDayOfWeek`: Retrieves the last day (Friday) of the current week.

`getEndDayOfMonth`: Retrieves the last day of the current month.

`getEndDayOfYear`: Retrieves the last day of the current year.

`getEndDayOfQuarter`: Retrieves the last day of the current quarter.

`getQuarter`: Retrieves the quarter (1, 2, 3, or 4) of the current date.

These methods enhance the functionality of the package by providing convenient ways to obtain specific dates such as the beginning or end of a quarter, week, month, or year. Feel free to review and provide feedback on the changes.

