### PR TITLE
GitHub Action Integration for Test Automation and Composer Updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [ 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3 ]
+
+    name: PHP ${{ matrix.php }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: error_reporting=E_ALL
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "beberlei/assert": "3.*"
     },
     "require-dev" : {
-        "phpunit/phpunit": "~4.0"
-    },  
+        "phpunit/phpunit": ">4.0"
+    },
     "autoload": {
         "psr-4": {
             "Morilog\\Jalali\\": "src"

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     ],
     "keywords": ["Laravel","Date","Datetime","Jalali", "Morilog"],
     "require": {
-        "php": "^7.0 | ^7.1 | ^7.2 | ^8.0 | ^8.1",
+        "php": "^7.0 | ^8.0",
         "nesbot/carbon": "^1.21 || ^2.0",
-        "beberlei/assert": "3.*"
+        "beberlei/assert": "^3.0"
     },
     "require-dev" : {
         "phpunit/phpunit": ">4.0"


### PR DESCRIPTION
Hi there,

In this pull request, I've implemented a GitHub Action to run tests on push and create a merge request. The tests now cover PHP versions 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, and 8.3.

Additionally, I've made changes in the composer.json file to update the `PHPUnit` version based on the PHP version. 

Furthermore, I've performed some clean-up tasks related to PHP versions. The syntax "^7.0" is now used to support all PHP versions from 7.0 to 7.4. 



