### PR TITLE
Add New Method: `getEndOfMonth`

### DIFF
--- a/src/Jalalian.php
+++ b/src/Jalalian.php
@@ -785,4 +785,17 @@ class Jalalian
 
         return [$yearDiff, $monthDiff, $dayDiff];
     }
+
+    public function getEndOfMonth(): Jalalian
+    {
+        return new static(
+            $this->getYear(),
+            $this->getMonth(),
+            $this->getMonthDays(),
+            $this->getHour(),
+            $this->getMinute(),
+            $this->getSecond(),
+            $this->getTimezone()
+        );
+    }
 }


### PR DESCRIPTION
Added a new method in `Jalalian` class that named `getEndOfMonth`

- Example
```
jdate()->getEndOfMonth()->format('Y-m-d') // 1403-05-31
```

@morilog 