### PR TITLE
Make nullable parameter type hint explicitly nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $date = Jalalian::forge('now - 10 minutes')->ago() // 10 دقیقه پیش
 
 
 ```php
-public static function now(\DateTimeZone $timeZone = null): Jalalian
+public static function now(?\DateTimeZone $timeZone = null): Jalalian
 
 $jDate = Jalalian::now();
 ```
@@ -77,7 +77,7 @@ $jDate = Jalalian::fromCarbon(Carbon::now());
 
 ---
 ```php
-public static function fromFormat(string $format, string $timestamp, \DateTimeZone$timeZone = null): Jalalian 
+public static function fromFormat(string $format, string $timestamp, ?\DateTimeZone$timeZone = null): Jalalian
 
 $jDate = Jalalian::fromFormat('Y-m-d H:i:s', '1397-01-18 12:00:40');
 ```
@@ -85,14 +85,14 @@ $jDate = Jalalian::fromFormat('Y-m-d H:i:s', '1397-01-18 12:00:40');
 
 ---
 ```php
-public static function forge($timestamp, \DateTimeZone $timeZone = null): Jalalian
+public static function forge($timestamp, ?\DateTimeZone $timeZone = null): Jalalian
 
 // Alias fo fromDatetime
 ```
 
 ---
 ```php
-public static function fromDateTime($dateTime, \DateTimeZone $timeZone = null): Jalalian
+public static function fromDateTime($dateTime, ?\DateTimeZone $timeZone = null): Jalalian
 
 $jDate = Jalalian::fromDateTime(Carbon::now())
 // OR 

--- a/src/Jalalian.php
+++ b/src/Jalalian.php
@@ -78,7 +78,7 @@ class Jalalian
         $this->timezone = $timezone;
     }
 
-    public static function now(\DateTimeZone $timeZone = null): Jalalian
+    public static function now(?\DateTimeZone $timeZone = null): Jalalian
     {
         return static::fromCarbon(Carbon::now($timeZone));
     }
@@ -102,12 +102,12 @@ class Jalalian
         );
     }
 
-    public static function fromFormat(string $format, string $timestamp, \DateTimeZone $timeZone = null): Jalalian
+    public static function fromFormat(string $format, string $timestamp, ?\DateTimeZone $timeZone = null): Jalalian
     {
         return static::fromCarbon(CalendarUtils::createCarbonFromFormat($format, $timestamp, $timeZone));
     }
 
-    public static function forge($timestamp, \DateTimeZone $timeZone = null): Jalalian
+    public static function forge($timestamp, ?\DateTimeZone $timeZone = null): Jalalian
     {
         return static::fromDateTime($timestamp, $timeZone);
     }
@@ -117,7 +117,7 @@ class Jalalian
      * @param \DateTimeZone|null $timeZone
      * @return Jalalian
      */
-    public static function fromDateTime($dateTime, \DateTimeZone $timeZone = null): Jalalian
+    public static function fromDateTime($dateTime, ?\DateTimeZone $timeZone = null): Jalalian
     {
         if (is_numeric($dateTime)) {
             return static::fromCarbon(Carbon::createFromTimestamp($dateTime, $timeZone));


### PR DESCRIPTION
Is solves the following deprecation messages in PHP 8.4:

```
DEPRECATED  Morilog\Jalali\Jalalian::__construct(): Implicitly marking parameter $timezone as nullable is deprecated, the explicit nullable type must be used instead in vendor/morilog/jalali/src/Jalalian.php on line 47.

DEPRECATED  Morilog\Jalali\Jalalian::now(): Implicitly marking parameter $timeZone as nullable is deprecated, the explicit nullable type must be used instead in vendor/morilog/jalali/src/Jalalian.php on line 81.

DEPRECATED  Morilog\Jalali\Jalalian::fromFormat(): Implicitly marking parameter $timeZone as nullable is deprecated, the explicit nullable type must be used instead in vendor/morilog/jalali/src/Jalalian.php on line 105.

DEPRECATED  Morilog\Jalali\Jalalian::forge(): Implicitly marking parameter $timeZone as nullable is deprecated, the explicit nullable type must be used instead in vendor/morilog/jalali/src/Jalalian.php on line 110.

DEPRECATED  Morilog\Jalali\Jalalian::fromDateTime(): Implicitly marking parameter $timeZone as nullable is deprecated, the explicit nullable type must be used instead in vendor/morilog/jalali/src/Jalalian.php on line 120.
```