### PR TITLE
[fix] update month and day regex patterns to allow single-digit values

### DIFF
--- a/src/CalendarUtils.php
+++ b/src/CalendarUtils.php
@@ -682,11 +682,11 @@ class CalendarUtils
         $keys = array(
             'Y' => array('year', '\d{4}'),
             'y' => array('year', '\d{2}'),
-            'm' => array('month', '\d{2}'),
+            'm' => array('month', '\d{1,2}'),
             'n' => array('month', '\d{1,2}'),
             'M' => array('month', '[A-Z][a-z]{3}'),
             'F' => array('month', '[A-Z][a-z]{2,8}'),
-            'd' => array('day', '\d{2}'),
+            'd' => array('day', '\d{1,2}'),
             'j' => array('day', '\d{1,2}'),
             'D' => array('day', '[A-Z][a-z]{2}'),
             'l' => array('day', '[A-Z][a-z]{6,9}'),


### PR DESCRIPTION
This pull request updates the `parseFromFormat` method in `src/CalendarUtils.php` to allow parsing dates with single-digit months and days, improving flexibility in date format handling.

Key changes in date parsing:

* [`src/CalendarUtils.php`](diffhunk://#diff-3e3d8a37d963cb428d77966bfacf2abed409b088a4ea6633d050df1d91e67f1dL685-R689): Modified the regex for `m` (month) and `d` (day) keys to accept both single-digit and double-digit values, enabling broader compatibility with date formats.

fix #190 