### PR TITLE
Make DateTimeZone parameters explicitly nullable

### DIFF
--- a/src/Jalalian.php
+++ b/src/Jalalian.php
@@ -40,9 +40,9 @@ class Jalalian
     private $second;
 
     /**
-     * @var \DateTimeZone
-     */
-    private $timezone;
+        * @var \DateTimeZone|null
+        */
+        private $timezone;
 
     public function __construct(
         int $year,


### PR DESCRIPTION
Fix PHP deprecation notices by marking timezone parameters nullable and updating phpdoc in `Jalalian.php`. See attached patch.